### PR TITLE
Remove chmod from standalone docker file

### DIFF
--- a/scripts/standalone-entrypoint.sh
+++ b/scripts/standalone-entrypoint.sh
@@ -249,12 +249,6 @@ if [ -n "$PLEX_PG_HOST" ]; then
         rm -rf "${crash_dir:?}/"*
         echo "Cleaned crash reports (prevents CrashUploader invocation)"
     fi
-
-    # Final permission fix
-    if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
-        echo "Fixing final permissions..."
-        chown -R plex:plex "/config/Library/Application Support/Plex Media Server" 2>/dev/null || true
-    fi
 else
     echo "PLEX_PG_HOST not set, skipping PostgreSQL initialization"
 fi


### PR DESCRIPTION
This causes a massive delay when you have a multi-TB library.

It's [already handled by Plex on start up](https://github.com/plexinc/pms-docker/blob/master/root/etc/cont-init.d/40-plex-first-run#L67).

If you _must_ chmod before continuing then it should respect the `CHANGE_CONFIG_DIR_OWNERSHIP` env option.

Specifically, if `PLEX_GID` and/or `PLEX_UID` are set, the user/group aren't updated until [it's set by Plex](https://github.com/plexinc/pms-docker/blob/master/root/etc/cont-init.d/40-plex-first-run#L38-L64), this causes a double chmod to 1000:1000 then a Plex instance that can't write to the files because the uid/gid don't match 1000:1000 requiring a triple chmod to fix the permissions.