### PR TITLE
chore: automate upstream image updates and patch releases

### DIFF
--- a/.github/upstream-digests.json
+++ b/.github/upstream-digests.json
@@ -1,0 +1,4 @@
+{
+  "linuxserver/plex:latest": "sha256:58f13a1df833fcb7b3499c6b52aec9d7473b93b1a1e2d2219db57e761e57903b",
+  "plexinc/pms-docker:latest": "sha256:c37106c57fed7a6624f5dee5a3ce460ff011f09a2aa7f4ee9e8dbbd08ae1b87e"
+}

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -1,0 +1,60 @@
+name: Check Upstream Updates
+
+on:
+  schedule:
+    # Run every 6 hours
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  check-updates:
+    name: Check for Upstream Updates
+    runs-on: ubuntu-latest
+    outputs:
+      updated: ${{ steps.check.outputs.updated }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history so we can push back
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run check script
+        id: check
+        run: python3 scripts/check-upstream-updates.py
+
+      - name: Commit and push changes
+        if: steps.check.outputs.updated == 'true'
+        run: |
+          set -eu
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          
+          VERSION_TAG="v${{ steps.check.outputs.version }}"
+          
+          git add VERSION .github/upstream-digests.json
+          git commit -m "chore: bump version to ${VERSION_TAG} for upstream updates"
+          
+          # Pull and rebase to prevent conflicts if main updated recently
+          git pull origin main --rebase
+          git push origin main
+          
+          git tag "${VERSION_TAG}"
+          git push origin "${VERSION_TAG}"
+
+  publish:
+    name: Publish Updated Images
+    needs: check-updates
+    if: needs.check-updates.outputs.updated == 'true'
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      version: v${{ needs.check-updates.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,12 @@ on:
         description: "Release version tag (for example: v0.9.16)"
         required: true
         type: string
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version tag (for example: v0.9.16)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -54,7 +60,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && inputs.version || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -70,7 +76,7 @@ jobs:
         id: version
         run: |
           set -eu
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
             echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           else
             echo "value=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
@@ -111,7 +117,7 @@ jobs:
         id: version
         run: |
           set -eu
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
             echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           else
             echo "value=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"

--- a/scripts/check-upstream-updates.py
+++ b/scripts/check-upstream-updates.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+
+DIGESTS_FILE = ".github/upstream-digests.json"
+VERSION_FILE = "VERSION"
+
+IMAGES = {
+    "linuxserver/plex:latest": "linuxserver/plex",
+    "plexinc/pms-docker:latest": "plexinc/pms-docker"
+}
+
+def get_remote_digest(repo, tag="latest"):
+    try:
+        # Get token
+        token_url = f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull"
+        req = urllib.request.Request(token_url)
+        with urllib.request.urlopen(req) as response:
+            data = json.loads(response.read().decode())
+            token = data["token"]
+        
+        # Get digest using HEAD request first
+        manifest_url = f"https://index.docker.io/v2/{repo}/manifests/{tag}"
+        req = urllib.request.Request(manifest_url, method="HEAD")
+        req.add_header("Authorization", f"Bearer {token}")
+        req.add_header("Accept", "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json")
+        
+        try:
+            with urllib.request.urlopen(req) as response:
+                digest = response.headers.get("Docker-Content-Digest")
+                if digest:
+                    return digest
+        except urllib.error.HTTPError:
+            # Fallback to GET request if HEAD is not allowed/fails
+            pass
+
+        req = urllib.request.Request(manifest_url, method="GET")
+        req.add_header("Authorization", f"Bearer {token}")
+        req.add_header("Accept", "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json")
+        with urllib.request.urlopen(req) as response:
+            return response.headers.get("Docker-Content-Digest")
+
+    except Exception as e:
+        print(f"Error fetching digest for {repo}:{tag}: {e}", file=sys.stderr)
+        return None
+
+def bump_patch_version(version_str):
+    parts = version_str.strip().split(".")
+    if len(parts) == 3:
+        try:
+            parts[2] = str(int(parts[2]) + 1)
+            return ".".join(parts)
+        except ValueError:
+            pass
+    raise ValueError(f"Invalid version format: '{version_str}'")
+
+def main():
+    if not os.path.exists(DIGESTS_FILE):
+        print(f"Error: {DIGESTS_FILE} not found.", file=sys.stderr)
+        sys.exit(1)
+        
+    if not os.path.exists(VERSION_FILE):
+        print(f"Error: {VERSION_FILE} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    with open(DIGESTS_FILE, "r") as f:
+        current_digests = json.load(f)
+
+    new_digests = {}
+    updated = False
+    changes = []
+
+    for key, repo in IMAGES.items():
+        print(f"Checking remote digest for {key}...")
+        remote_digest = get_remote_digest(repo)
+        if not remote_digest:
+            print(f"Could not retrieve digest for {key}. Skipping.", file=sys.stderr)
+            new_digests[key] = current_digests.get(key, "")
+            continue
+            
+        old_digest = current_digests.get(key)
+        new_digests[key] = remote_digest
+        
+        if old_digest != remote_digest:
+            print(f"  -> UPDATE DETECTED for {key}!")
+            print(f"     Old: {old_digest}")
+            print(f"     New: {remote_digest}")
+            updated = True
+            changes.append(f"upstream image {key} updated")
+        else:
+            print(f"  -> Up-to-date ({remote_digest[:15]}...)")
+
+    if updated:
+        with open(VERSION_FILE, "r") as f:
+            old_version = f.read().strip()
+            
+        try:
+            new_version = bump_patch_version(old_version)
+        except ValueError as e:
+            print(f"Error bumping version: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Bumping version from {old_version} to {new_version}...")
+        
+        with open(VERSION_FILE, "w") as f:
+            f.write(new_version + "\n")
+            
+        with open(DIGESTS_FILE, "w") as f:
+            json.dump(new_digests, f, indent=2)
+            f.write("\n")
+
+        print("Updates saved.")
+        
+        # Set GitHub Action outputs
+        if "GITHUB_OUTPUT" in os.environ:
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write(f"updated=true\n")
+                f.write(f"version={new_version}\n")
+                f.write(f"changes={'; '.join(changes)}\n")
+    else:
+        print("No updates found.")
+        if "GITHUB_OUTPUT" in os.environ:
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write("updated=false\n")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds automated checks for upstream Docker image updates (`linuxserver/plex:latest` and `plexinc/pms-docker:latest`) and automates new patch releases for `plex-postgresql`.

### How it works:
1. A new scheduled GitHub Actions workflow (`.github/workflows/check-updates.yml`) runs every 6 hours (and can be triggered manually).
2. It executes a lightweight Python script (`scripts/check-upstream-updates.py`) that queries the public Docker Hub registry for the latest multi-arch manifest digests of the two base images.
3. If an update is detected, it compares it against the recorded digests in `.github/upstream-digests.json`. If they differ:
   - The patch version in the `VERSION` file is incremented (e.g. `1.3.1` -> `1.3.2`).
   - `.github/upstream-digests.json` is updated with the new digests.
   - The workflow commits these changes, pushes them back to `main`, and creates/pushes a matching Git tag (e.g. `v1.3.2`).
   - The workflow calls the `docker-publish.yml` workflow (which has been converted to a reusable workflow using `workflow_call`) to build and publish the new Docker images.

### Changes:
- Added `scripts/check-upstream-updates.py`
- Added `.github/upstream-digests.json`
- Added `.github/workflows/check-updates.yml`
- Modified `.github/workflows/docker-publish.yml` to support `workflow_call` and checkout the correct version.